### PR TITLE
Workaround for dealing with i8 in xmlrpc_decode

### DIFF
--- a/HM-XMLRPC-Client/Client.php
+++ b/HM-XMLRPC-Client/Client.php
@@ -226,8 +226,10 @@ class Client
     {
         $request = xmlrpc_encode_request($methodName, $params);
         $response = $this->sendRequest($request);
-        $response = xmlrpc_decode(trim($response)); //Without the trim function returns null
-        return $response;
+
+    	$response = str_replace('i8>', 'i4>', $response);
+
+        return xmlrpc_decode(trim($response)); //Without the trim function returns null
     }
 }
 


### PR DESCRIPTION
xmlrpc_decode doesn't handle int64 correctly, this is a workaround by replacing i8 with i4